### PR TITLE
Fix builder custom operation naming consistency and XML docs

### DIFF
--- a/FsMake/ParallelMaybe.fs
+++ b/FsMake/ParallelMaybe.fs
@@ -55,13 +55,26 @@ module ParallelMaybe =
         member _.Yield(_) : ParallelMaybe list =
             []
 
+        /// <summary>
+        /// Adds a <see cref="T:Step" /> that will always be run.
+        /// </summary>
+        /// <param name="state">Current state of the computation expression.</param>
+        /// <param name="step">The <see cref="T:Step" /> to add.</param>
+        /// <returns>Updated state of the computation expression.</returns>
         [<CustomOperation("run")>]
-        member _.RunStep(maybes: ParallelMaybe list, step: Step) : ParallelMaybe list =
-            maybes @ [ PStep step ]
+        member _.RunStep(state: ParallelMaybe list, step: Step) : ParallelMaybe list =
+            state @ [ PStep step ]
 
-        [<CustomOperation("maybe_run")>]
-        member _.Maybe(maybes: ParallelMaybe list, step: Step, cond: bool) : ParallelMaybe list =
-            maybes @ [ PMaybe (step, cond) ]
+        /// <summary>
+        /// Adds a <see cref="T:Step" /> that will be run when <paramref name="cond" /> is true.
+        /// </summary>
+        /// <param name="state">Current state of the computation expression.</param>
+        /// <param name="step">The <see cref="T:Step" /> to add.</param>
+        /// <param name="cond">The condition that must be true for the <paramref name="step" /> to run.</param>
+        /// <returns>Updated state of the computation expression.</returns>
+        [<CustomOperation("run_maybe")>]
+        member _.RunMaybe(state: ParallelMaybe list, step: Step, cond: bool) : ParallelMaybe list =
+            state @ [ PMaybe (step, cond) ]
 
 /// <summary>
 /// Auto-opened module containing functions for using <see cref="T:ParallelMaybe`1" /> computation expressions.
@@ -84,7 +97,7 @@ module ParallelMaybeBuilders =
     ///     Pipeline.create "example" {
     ///         run_parallel_maybes {
     ///             run emptyStep1
-    ///             maybe_run emptyStep2 condition
+    ///             run_maybe emptyStep2 condition
     ///             run emptyStep3
     ///         }
     ///     }

--- a/FsMake/ParallelMaybe.fs
+++ b/FsMake/ParallelMaybe.fs
@@ -77,13 +77,13 @@ module ParallelMaybe =
             state @ [ PMaybe (step, cond) ]
 
 /// <summary>
-/// Auto-opened module containing functions for using <see cref="T:ParallelMaybe`1" /> computation expressions.
+/// Auto-opened module containing functions for using <see cref="T:ParallelMaybe" /> computation expressions.
 /// </summary>
 [<AutoOpen>]
 module ParallelMaybeBuilders =
     // fsharplint:disable
     /// <summary>
-    /// Creates a <see cref="T:ParallelMaybe" /> <c>list</c> using a <see cref="T:ParallelMaybe.Builder" /> computation expression.
+    /// Creates a <see cref="T:ParallelMaybe" /> <c>list</c> using a <see cref="T:FsMake.ParallelMaybeModule.Builder" /> computation expression.
     /// </summary>
     /// <example>
     /// <code lang="fsharp">

--- a/FsMake/Pipeline.fs
+++ b/FsMake/Pipeline.fs
@@ -252,6 +252,9 @@ module Pipeline =
             | Some x -> { x with Name = name }
             | None -> { Name = name; Stages = [] }
 
+        member _.Zero() : unit =
+            ()
+
         member _.Delay(f: unit -> 'T) : 'T =
             f ()
 
@@ -273,29 +276,57 @@ module Pipeline =
         member _.Combine(_: 'T, _: 'T) : unit =
             ()
 
+        /// <summary>
+        /// Adds a <see cref="T:Step" /> that will always be run.
+        /// </summary>
+        /// <param name="state">Unused.</param>
+        /// <param name="step">The <see cref="T:Step" /> to add.</param>
+        /// <returns>Unit.</returns>
         [<CustomOperation("run")>]
-        member _.RunStep(_: unit, step: Step) : unit =
+        member _.RunStep(state: unit, step: Step) : unit =
             pipeline <-
                 { pipeline with
                     Stages = pipeline.Stages @ [ SequentialStage step ]
                 }
 
-        [<CustomOperation("maybe_run")>]
-        member _.MaybeRun(_: unit, step: Step, cond: bool) : unit =
+        /// <summary>
+        /// Adds a <see cref="T:Step" /> that will be run conditionally.
+        /// <para>The <see cref="T:Step" /> will only run if <paramref name="cond" /> is true.</para>
+        /// </summary>
+        /// <param name="state">Unused.</param>
+        /// <param name="step">The <see cref="T:Step" /> to conditionally run.</param>
+        /// <param name="cond">The condition that must be true for the step to run.</param>
+        /// <returns>Unit.</returns>
+        [<CustomOperation("run_maybe")>]
+        member _.RunMaybe(state: unit, step: Step, cond: bool) : unit =
             pipeline <-
                 { pipeline with
                     Stages = pipeline.Stages @ [ SequentialMaybeStage (step, cond) ]
                 }
 
+        /// <summary>
+        ///  Adds a list of <see cref="T:Step" />s to be run in parralel.
+        /// </summary>
+        /// <param name="state">Unused.</param>
+        /// <param name="steps">The list of <see cref="T:Step" />s that will be run in parallel.</param>
+        /// <returns></returns>
         [<CustomOperation("run_parallel")>]
-        member _.RunParallel(_: unit, steps: Step list) : unit =
+        member _.RunParallel(state: unit, steps: Step list) : unit =
             pipeline <-
                 { pipeline with
                     Stages = pipeline.Stages @ [ ParallelStage steps ]
                 }
 
-        [<CustomOperation("maybe_run_parallel")>]
-        member _.MaybeRunParallel(_: unit, steps: Step list, cond: bool) : unit =
+        /// <summary>
+        /// Adds steps that will be run in parallel.
+        /// <para>The steps will only run if <paramref name="cond" /> is true.</para>
+        /// </summary>
+        /// <param name="state">Unused.</param>
+        /// <param name="steps">The steps to conditionally run in parallel.</param>
+        /// <param name="cond">The condition that must be true for the steps to run.</param>
+        /// <returns>Unit.</returns>
+        [<CustomOperation("run_parallel_maybe")>]
+        member _.RunParallelMaybe(state: unit, steps: Step list, cond: bool) : unit =
             pipeline <-
                 { pipeline with
                     Stages = pipeline.Stages @ [ ParallelMaybeStage (steps, cond) ]

--- a/FsMake/Pipelines.fs
+++ b/FsMake/Pipelines.fs
@@ -97,7 +97,7 @@ module Pipelines =
             (pipelines, vars)
 
         /// <summary>
-        /// Sets the when to prefix a <see cref="T:Step" />'s console output.
+        /// Sets when to prefix a <see cref="T:Step" />'s console output.
         /// </summary>
         /// <param name="state">The current state of the computation expression.</param>
         /// <param name="prefixOption">The <see cref="T:Prefix.PrefixOption" />.</param>

--- a/FsMake/Pipelines.fs
+++ b/FsMake/Pipelines.fs
@@ -58,31 +58,55 @@ module Pipelines =
 
             (pipelines, vars)
 
+        /// <summary>
+        /// Adds a <see cref="T:Pipeline" /> to the <see cref="T:Pipelines" />.
+        /// </summary>
+        /// <param name="state">The current state of the computation expression.</param>
+        /// <param name="pipeline">The <see cref="T:Pipeline" /> to be added.</param>
+        /// <typeparam name="'a">The types of the variables in the computation expression's state.</typeparam>
+        /// <returns>Updated computation expression state.</returns>
         [<CustomOperation("add", MaintainsVariableSpace = true)>]
-        member _.Add((pipelines: Pipelines, vars: 'a), [<ProjectionParameter>] f: 'a -> Pipeline) : Pipelines * 'a =
-            let pipeline = f vars
+        member _.Add(state: (Pipelines * 'a), [<ProjectionParameter>] pipeline: 'a -> Pipeline) : Pipelines * 'a =
+            let pipelines, vars = state
+            let newPipeline = pipeline vars
 
             let pipelines =
                 { pipelines with
-                    Pipelines = pipelines.Pipelines @ [ pipeline ]
+                    Pipelines = pipelines.Pipelines @ [ newPipeline ]
                 }
 
             (pipelines, vars)
 
+        /// <summary>
+        /// Sets the default <see cref="T:Pipeline" /> to be run when one is not specified.
+        /// </summary>
+        /// <param name="state">The current state of the computation expression.</param>
+        /// <param name="pipeline">The <see cref="T:Pipeline" /> to be used as the default.</param>
+        /// <typeparam name="'a">The types of the variables in the computation expression's state.</typeparam>
+        /// <returns>Updated computation expression state.</returns>
         [<CustomOperation("default_pipeline", MaintainsVariableSpace = true)>]
-        member _.DefaultPipeline((pipelines: Pipelines, vars: 'a), [<ProjectionParameter>] f: 'a -> Pipeline) : Pipelines * 'a =
-            let pipeline = f vars
+        member _.DefaultPipeline(state: (Pipelines * 'a), [<ProjectionParameter>] pipeline: 'a -> Pipeline) : Pipelines * 'a =
+            let pipelines, vars = state
+            let defaultPipeline = pipeline vars
 
             let pipelines =
                 { pipelines with
-                    Default = Some pipeline
+                    Default = Some defaultPipeline
                 }
 
             (pipelines, vars)
 
+        /// <summary>
+        /// Sets the when to prefix a <see cref="T:Step" />'s console output.
+        /// </summary>
+        /// <param name="state">The current state of the computation expression.</param>
+        /// <param name="prefixOption">The <see cref="T:Prefix.PrefixOption" />.</param>
+        /// <typeparam name="'a">The types of the variables in the computation expression's state.</typeparam>
+        /// <returns>Updated computation expression state.</returns>
         [<CustomOperation("step_prefix", MaintainsVariableSpace = true)>]
-        member _.StepPrefix((pipelines: Pipelines, vars: 'a), [<ProjectionParameter>] f: 'a -> Prefix.PrefixOption) : Pipelines * 'a =
-            let option = f vars
+        member _.StepPrefix(state: (Pipelines * 'a), [<ProjectionParameter>] prefixOption: 'a -> Prefix.PrefixOption) : Pipelines * 'a =
+            let pipelines, vars = state
+            let option = prefixOption vars
 
             let pipelines = { pipelines with StepPrefix = option }
 


### PR DESCRIPTION
Resolves #33 , resolves #32 